### PR TITLE
docs: Add gradle configurations graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # Groomr
 
 [![Build → Test → Lint](https://github.com/mcgalanes/groomr/actions/workflows/ci.yml/badge.svg)](https://github.com/mcgalanes/groomr/actions/workflows/ci.yml)
+
+## Module Config
+
+```mermaid
+
+flowchart LR
+
+  classDef appModule fill:#AEFFDA,color:#000
+  classDef featureModule fill:#FFDAAE,color:#000
+  classDef coreModule fill:#DAAEFF,color:#000
+  
+  subgraph :app
+    app([:app]):::appModule
+  end
+  subgraph :feature
+    app --> userstory:create([:userstory:create]):::featureModule
+    app --> userstory:list([:userstory:list]):::featureModule
+  end
+  subgraph :core 
+    userstory:create --> ui([:ui]):::coreModule
+    userstory:list --> domain([:domain]):::coreModule
+    userstory:list --> ui([:ui]):::coreModule
+    userstory:list --> testing([:testing]):::coreModule
+    data --> domain([:domain]):::coreModule
+    app --> ui([:ui]):::coreModule
+    app --> data([:data]):::coreModule
+  end
+```

--- a/build-logic/convention/src/main/kotlin/com/github/mcgalanes/groomr/modularization/Compose.kt
+++ b/build-logic/convention/src/main/kotlin/com/github/mcgalanes/groomr/modularization/Compose.kt
@@ -20,7 +20,6 @@ internal fun Project.configureCompose(commonExtension: BaseExtension) {
         dependencies {
             add("implementation", platform(libs.findLibrary("androidx.compose.bom").get()))
             add("androidTestImplementation", libs.findLibrary("androidx.compose.ui.test.junit4").get())
-            add("androidTestImplementation", project(":core:testing"))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,6 @@ buildscript {
     }
 }
 
-// Lists all plugins used throughout the project without applying them.
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false


### PR DESCRIPTION
## Changes
Add gradle configurations graph to show relations between :modules

<img width="577" alt="groomr_gradle_config_graph" src="https://github.com/McGalanes/groomr/assets/17271561/29c5c725-2213-4379-ad57-a4a7c14fbdf4">
